### PR TITLE
Build transpiled writer packages, for testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+
+module.exports.SimpleWriterPackage = require('./dist/SimpleWriterPackage');

--- a/make.js
+++ b/make.js
@@ -28,6 +28,15 @@ b.serve({
 })
 
 function _client(devMode) {
+  b.js('lib/simple-writer/SimpleWriterPackage.js', {
+    target: {
+      dest: './dist/SimpleWriterPackage.js',
+      format: 'umd',
+      moduleName: 'SimpleWriterPackage'
+    },
+    buble: !devMode
+  })
+
   b.css('./app/app.css', 'dist/app.css', { variables: true })
   b.js('app/app.js', {
     target: {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Reference implementation for a custom Substance editor",
   "module": "index.es.js",
   "jsnext:main": "index.es.js",
+  "main": "index.js",
   "devDependencies": {
     "substance": "1.0.0-beta.6.2",
     "font-awesome": "4.5.0",
@@ -10,7 +11,8 @@
   },
   "scripts": {
     "build": "node make",
-    "start": "node make -s -w"
+    "start": "node make -s -w",
+    "prepublish": "node make"
   },
   "version": "1.0.0-beta.6",
   "files": [


### PR DESCRIPTION
My current issue is the round trip time of ~10 s per change when developing https://github.com/TryTopics/collab-writer/pull/1. Slow server builds are a good driver to be test driven, but fast node+mocha is ES6 without import and export.